### PR TITLE
Preview Sections

### DIFF
--- a/scripts/Preview.js
+++ b/scripts/Preview.js
@@ -1,0 +1,7 @@
+export const preview = text => {
+    let textArray = []
+    for(let i = 0; i < 150; i++){
+        textArray.push(text[i])
+    }
+    return textArray.join("")
+}

--- a/scripts/attractions/Attraction.js
+++ b/scripts/attractions/Attraction.js
@@ -1,10 +1,57 @@
+import { preview } from "../Preview.js"
+
+const eventHub = document.querySelector("#container")
+
+export const bizarreCardPreviewHTML = (api) => {
+    const shortenedDescription = preview(api.description)
+
+    return `
+    <div id="bizzarreCard--${api.id}" class="previewCard">
+        <h3 class="card__category">Bizarre Attraction</h3>
+        <br>
+        <h4 class="bizzarreCard__title title">${api.name}</h4>
+        <div class="bizzarreCard__location location">${api.state}, ${api.city}</div>
+        <br>
+        <div class="bizarreCard__preview preview">${shortenedDescription}....</div>
+        <br>
+        <button id="bizzarreCard__button" value="${api.id}">Details</button>
+    </div>
+    `
+}
+
+eventHub.addEventListener("click", clickEvent => {
+    if(clickEvent.target.id === "bizzarreCard__button") {
+        const customEvent = new CustomEvent("attractionsDetailButtonClicked", {
+            detail: {
+                attractionThatWasChosen: clickEvent.target.value
+            }
+        })
+        eventHub.dispatchEvent(customEvent)
+    }
+})
+
 export const bizarreCardHTML = (api) => {
     return `
     <div id="bizzarreCard--${api.id}" class="previewCard">
         <h3 class="card__category">Bizarre Attraction</h3>
-        <div class="bizzarreCard__location location">${api.state}, ${api.city}</div>
+        <br>
         <h4 class="bizzarreCard__title title">${api.name}</h4>
-        <button id="bizzarreCard__button">Details</button>
+        <div class="bizzarreCard__location location">${api.state}, ${api.city}</div>
+        <br>
+        <div class="bizarreCard__preview preview">${api.description}</div>
+        <br>
+        <button id="bizzarreCard__minimize" value="${api.id}">Minimize</button>
     </div>
     `
 }
+
+eventHub.addEventListener("click", clickEvent => {
+    if(clickEvent.target.id === "bizzarreCard__minimize") {
+        const customEvent = new CustomEvent("attractionMinimizeButtonClicked", {
+            detail: {
+                attractionThatWasChosen: clickEvent.target.value
+            }
+        })
+        eventHub.dispatchEvent(customEvent)
+    }
+})

--- a/scripts/attractions/AttractionList.js
+++ b/scripts/attractions/AttractionList.js
@@ -1,5 +1,5 @@
 import { getAttractions, useAttractions  } from './AttractionProvider.js'
-import { bizarreCardHTML } from "./Attraction.js"
+import { bizarreCardHTML, bizarreCardPreviewHTML } from "./Attraction.js"
 
 const attractionsElement = document.querySelector("#bizzarreCard")
 const eventHub = document.querySelector("#container")
@@ -15,11 +15,37 @@ eventHub.addEventListener("attractionSelected", changeEvent => {
                 return taco.id === parseInt(changeEvent.detail.attractionThatWasChosen)
             })
             // console.log(chosenAttraction)
-            const bizarreHTML = bizarreCardHTML(chosenAttraction)
+            const bizarreHTML = bizarreCardPreviewHTML(chosenAttraction)
             render(bizarreHTML)
         })
     }
 })   
+
+eventHub.addEventListener("attractionsDetailButtonClicked", clickEvent => {
+    getAttractions()
+    .then(() => {
+        const attractions = useAttractions()
+        const chosenAttractionDescription = attractions.find( chosen => {
+            return chosen.id === parseInt(clickEvent.detail.attractionThatWasChosen)
+        })
+        const attractionHTML = bizarreCardHTML(chosenAttractionDescription)
+        render(attractionHTML)
+    })
+})
+
+eventHub.addEventListener("attractionMinimizeButtonClicked", changeEvent => {
+    if (changeEvent.target.id !== 0) {
+        getAttractions()
+            .then(() => {
+                const attractions = useAttractions();
+                const chosenAttraction = attractions.find ( taco => {
+                    return taco.id === parseInt(changeEvent.detail.attractionThatWasChosen)
+                })
+                const bizarreHTML = bizarreCardPreviewHTML(chosenAttraction)
+                render(bizarreHTML)
+            })
+        }
+    })   
 
 const render = (bizarreObj) => {
     attractionsElement.innerHTML = bizarreObj

--- a/scripts/eateries/Eatery.js
+++ b/scripts/eateries/Eatery.js
@@ -1,12 +1,62 @@
-export const eateryCardHTML = (api) => {
+import { preview } from "../Preview.js"
+
+const eventHub = document.querySelector("#container")
+
+export const eateryCardPreviewHTML = (api) => {
+   const shortenedDescription = preview(api.description)
+    
     return `
     <div id="${api.id}" class="previewCard">
         <h3 class="card__category">Eatery</h3>
-        <div class="eateryCard__location">${api.state}, ${api.city}</div>
-        <h4 class="eateryCard__title">${api.businessName}</h4>
-        <button id="eateryCard__button">Details</button>
+        <br>
+        <h4 class="eateryCard__title title">${api.businessName}</h4>
+        <div class="eateryCard__location location">${api.state}, ${api.city}</div>
+        <br>
+        <div class="eateryCard__preview preview">${shortenedDescription}....</div>
+        <br>
+        <button id="eateryCard__button" value="${api.id}">Details</button>
     </div>
               `
 }
+
+eventHub.addEventListener("click", clickEvent => {
+    if(clickEvent.target.id === "eateryCard__button") {
+        const customEvent = new CustomEvent("eateryDetailButtonClicked", {
+            detail: {
+                eateryThatWasChosen: clickEvent.target.value
+            }
+        })
+        eventHub.dispatchEvent(customEvent)
+    }
+})
+
+export const eateryCardHTML = (api) => {
+    return `
+     <div id="${api.id}" class="previewCard">
+         <h3 class="card__category">Eatery</h3>
+         <br>
+         <h4 class="eateryCard__title title">${api.businessName}</h4>
+         <div class="eateryCard__location location">${api.state}, ${api.city}</div>
+         <br>
+         <div class="eateryCard__preview preview">${api.description}</div>
+         <br>
+         <button id="eateryCard__minimize" value="${api.id}">Minimize</button>
+     </div>
+               `
+ }
+
+eventHub.addEventListener("click", clickEvent => {
+    if(clickEvent.target.id === "eateryCard__minimize") {
+        const customEvent = new CustomEvent("eateryMinimizeButtonClicked", {
+            detail: {
+                eateryThatWasChosen: clickEvent.target.value
+            }
+        })
+        eventHub.dispatchEvent(customEvent)
+    }
+})
+
+
+
 
 

--- a/scripts/eateries/EateryList.js
+++ b/scripts/eateries/EateryList.js
@@ -1,5 +1,5 @@
 import { getEateries, useEateries } from "./EateryProvider.js"
-import { eateryCardHTML } from "./Eatery.js"
+import { eateryCardHTML, eateryCardPreviewHTML } from "./Eatery.js"
 
 const contentElement = document.querySelector("#eateryCard")
 const eventHub = document.querySelector("#container")
@@ -13,7 +13,37 @@ eventHub.addEventListener("eaterySelect", changeEvent => {
                     return chosen.id === parseInt(changeEvent.detail.eateryThatWasChosen)
                 })
                 
-                const eateryHTML = eateryCardHTML(chosenEatery)
+                const eateryHTML = eateryCardPreviewHTML(chosenEatery)
+                render(eateryHTML)
+            })
+    }
+})
+
+eventHub.addEventListener("eateryDetailButtonClicked", clickEvent => {
+    // debugger
+    getEateries()
+            .then(() => {
+                const eateries = useEateries()
+                const chosenEateryDescription = eateries.find( chosen => {
+                    return chosen.id === parseInt(clickEvent.detail.eateryThatWasChosen)
+                })
+                
+                const eateryHTML = eateryCardHTML(chosenEateryDescription)
+                render(eateryHTML)
+            })
+            
+})
+
+eventHub.addEventListener("eateryMinimizeButtonClicked", changeEvent => {
+    if (changeEvent.target.id !== 0) {
+        getEateries()
+            .then(() => {
+                const eateries = useEateries()
+                const chosenEatery = eateries.find( chosen => {
+                    return chosen.id === parseInt(changeEvent.detail.eateryThatWasChosen)
+                })
+                
+                const eateryHTML = eateryCardPreviewHTML(chosenEatery)
                 render(eateryHTML)
             })
     }

--- a/scripts/eateries/EateryProvider.js
+++ b/scripts/eateries/EateryProvider.js
@@ -10,7 +10,6 @@ export const getEateries = () => {
     .then(
         parsedEateries => {
             eateriesArray = parsedEateries
-            console.log(eateriesArray)
         }
     )
 }

--- a/scripts/eateries/EaterySelect.js
+++ b/scripts/eateries/EaterySelect.js
@@ -29,6 +29,5 @@ eventHub.addEventListener("change", changeEvent => {
             }
         })
         eventHub.dispatchEvent(customEvent)
-        console.log(customEvent)
     }
 })

--- a/scripts/parks/Park.js
+++ b/scripts/parks/Park.js
@@ -1,10 +1,48 @@
+const eventHub = document.querySelector("#container")
+
 export const parkCardHTML = (api) => {
     return `
     <div id="${api.id}" class="previewCard">
         <h3 class="card__category">Park</h3>
         <img class="parkCard__image" src="${api.images[0].url}">
         <h4 class="parkCard__title title">${api.fullName}</h4>
-        <button id="parkCard__button">Details</button>
+        <button id="parkCard__button" value="${api.id}">Details</button>
     </div>
     `
 }
+
+eventHub.addEventListener("click", clickEvent => {
+    if(clickEvent.target.id === "parkCard__button") {
+        const customEvent = new CustomEvent("parkDetailButtonClicked", {
+            detail: {
+                parkThatWasChosen: clickEvent.target.value
+            }
+        })
+        eventHub.dispatchEvent(customEvent)
+    }
+})
+
+export const parkCardDescriptionHTML = (api) => {
+    return `
+    <div id="${api.id}" class="previewCard">
+        <h3 class="card__category">Park</h3>
+        <img class="parkCard__image" src="${api.images[0].url}">
+        <h4 class="parkCard__title title">${api.fullName}</h4>
+        <br>
+         <div class="parkCard__description description">${api.description}</div>
+         <br>
+        <button id="parkCard__minimize" value="${api.id}">Minimize</button>
+    </div>
+    `
+}
+
+eventHub.addEventListener("click", clickEvent => {
+    if(clickEvent.target.id === "parkCard__minimize") {
+        const customEvent = new CustomEvent("parkMinimizeButtonClicked", {
+            detail: {
+                parkThatWasChosen: clickEvent.target.value
+            }
+        })
+        eventHub.dispatchEvent(customEvent)
+    }
+})

--- a/scripts/parks/ParkList.js
+++ b/scripts/parks/ParkList.js
@@ -1,6 +1,6 @@
 
 import { getParks, useParks  } from './ParkProvider.js'
-import { parkCardHTML } from "./Park.js"
+import { parkCardHTML, parkCardDescriptionHTML } from "./Park.js"
 
 const parksElement = document.querySelector("#parkCard")
 const eventHub = document.querySelector("#container")
@@ -22,6 +22,35 @@ eventHub.addEventListener("parkSelect", changeEvent => {
     }
 })
 
+eventHub.addEventListener("parkDetailButtonClicked", changeEvent => {
+    console.log("parks reciever pinged")    
+    // debugger
+    if (changeEvent.target.id !== 0) {
+    getParks()
+        .then(() => {
+            const parks = useParks()
+            const chosenPark = parks.find( taco => {
+                return taco.id === changeEvent.detail.parkThatWasChosen
+            })
+            const parksHTML = parkCardDescriptionHTML(chosenPark)
+            render(parksHTML)
+        })
+    }
+})
+
+eventHub.addEventListener("parkMinimizeButtonClicked", changeEvent => {
+    if (changeEvent.target.id !== 0) {
+        getParks()
+            .then(() => {
+                const parks = useParks()
+                const chosenPark = parks.find( taco => {
+                    return taco.id === changeEvent.detail.parkThatWasChosen
+                })
+                const parksHTML = parkCardHTML(chosenPark)
+                render(parksHTML)
+        })
+    }
+})
 
 const render = (parkObj) => {
     parksElement.innerHTML = parkObj


### PR DESCRIPTION
# Description
Added description preview sections on Eateries and Attractions. The details button populates the full descriptions for all three categories. The minimize button returns the cards to their state after the select.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions
Please describe the tests required to verify your changes. Provide instructions so PR Tester can check functionality. Please also list any relevant details for your tests
1. `git fetch --all`
1. `git checkout wb-previews`
1. `serve`

